### PR TITLE
Fix CVE-2021-43618 and CVE-2022-0778

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -1,5 +1,5 @@
 FROM openjdk:8u292-jre-slim
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends liblz4-1=1.8.3-1+deb10u1 libgcrypt20=1.8.4-5+deb10u1 libgnutls30=3.6.7-4+deb10u7 libhogweed4=3.4.1-1+deb10u1 libssl1.1=1.1.1d-0+deb10u7 openssl=1.1.1d-0+deb10u7 && \
+    apt-get install -y --no-install-recommends liblz4-1=1.8.3-1+deb10u1 libgcrypt20=1.8.4-5+deb10u1 libgnutls30=3.6.7-4+deb10u7 libhogweed4=3.4.1-1+deb10u1 libssl1.1=1.1.1d-0+deb10u8 openssl=1.1.1d-0+deb10u8 libgmp10=2:6.1.2+dfsg-4+deb10u1 && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix the following vulnerabilities. They disappear now with the PR.
```
Total: 3 (HIGH: 3, CRITICAL: 0)

+-----------+------------------+----------+-------------------+------------------------+---------------------------------------+
|  LIBRARY  | VULNERABILITY ID | SEVERITY | INSTALLED VERSION |     FIXED VERSION      |                 TITLE                 |
+-----------+------------------+----------+-------------------+------------------------+---------------------------------------+
| libgmp10  | CVE-2021-43618   | HIGH     | 2:6.1.2+dfsg-4    | 2:6.1.2+dfsg-4+deb10u1 | gmp: Integer overflow and resultant   |
|           |                  |          |                   |                        | buffer overflow via crafted input     |
|           |                  |          |                   |                        | -->avd.aquasec.com/nvd/cve-2021-43618 |
+-----------+------------------+          +-------------------+------------------------+---------------------------------------+
| libssl1.1 | CVE-2022-0778    |          | 1.1.1d-0+deb10u7  | 1.1.1d-0+deb10u8       | openssl: Infinite loop in             |
|           |                  |          |                   |                        | BN_mod_sqrt() reachable               |
|           |                  |          |                   |                        | when parsing certificates             |
|           |                  |          |                   |                        | -->avd.aquasec.com/nvd/cve-2022-0778  |
+-----------+                  +          +                   +                        +                                       +
| openssl   |                  |          |                   |                        |                                       |
|           |                  |          |                   |                        |                                       |
|           |                  |          |                   |                        |                                       |
|           |                  |          |                   |                        |                                       |
+-----------+------------------+----------+-------------------+------------------------+---------------------------------------+
```