### PR TITLE
Update for CVE-2022-1271

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -9,4 +9,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl=1.1.1n-0+deb11u1 \
     libgmp10=2:6.2.1+dfsg-1+deb11u1 \
     zlib1g=1:1.2.11.dfsg-2+deb11u1 \
+    gzip=1.10-4+deb11u1 \
+    liblzma5=5.2.5-2.1~deb11u1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR updates two Debian packages according to CVE-2022-1271.
(The weekly scan job detected it https://github.com/scalar-labs/docker/runs/6087238726?check_suite_focus=true)