### PR TITLE
Patch for CVE-2022-1664

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -11,4 +11,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g=1:1.2.11.dfsg-2+deb11u1 \
     gzip=1.10-4+deb11u1 \
     liblzma5=5.2.5-2.1~deb11u1 \
+    dpkg=1.20.10 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR fixes CVE-2022-1664 (the `dpkg` package 😄)
Reference: https://avd.aquasec.com/nvd/2022/cve-2022-1664