### PR TITLE
Fix CVE-2021-46828

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -12,4 +12,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gzip=1.10-4+deb11u1 \
     liblzma5=5.2.5-2.1~deb11u1 \
     dpkg=1.20.10 \
+    libtirpc-common=1.3.1-1+deb11u1 \
+    libtirpc3=1.3.1-1+deb11u1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This fixes CVE-2021-46828 detected by the Scalar DB CI 
https://github.com/scalar-labs/scalardb/runs/7717533906?check_suite_focus=true
![image](https://user-images.githubusercontent.com/3835021/183327338-c2a1d0da-a1b2-4c3c-be9f-56d91dbf4fe7.png)