### PR TITLE
Fix CVE-2021-3999, CVE-2022-1586 and CVE-2022-1587

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -14,4 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg=1.20.10 \
     libtirpc-common=1.3.1-1+deb11u1 \
     libtirpc3=1.3.1-1+deb11u1 \
+    libc-bin=2.31-13+deb11u4 \
+    libc6=2.31-13+deb11u4 \
+    libpcre2-8-0=10.36-2+deb11u1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This fixes the following CVE 
![image](https://user-images.githubusercontent.com/3835021/189576954-6025218f-1c7d-4007-9c00-6d9d9c759daa.png)
