### PR TITLE
Fix CVE-2021-46848

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -17,4 +17,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libc-bin=2.31-13+deb11u4 \
     libc6=2.31-13+deb11u4 \
     libpcre2-8-0=10.36-2+deb11u1 \
+    libtasn1-6=4.16.0-2+deb11u1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR fixes https://avd.aquasec.com/nvd/2021/cve-2021-46848/