### PR TITLE
Update the libc Debiain packages

### DIFF
--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg=1.20.10 \
     libtirpc-common=1.3.1-1+deb11u1 \
     libtirpc3=1.3.1-1+deb11u1 \
-    libc-bin=2.31-13+deb11u4 \
-    libc6=2.31-13+deb11u4 \
+    libc-bin=2.31-13+deb11u5 \
+    libc6=2.31-13+deb11u5 \
     libpcre2-8-0=10.36-2+deb11u1 \
     libtasn1-6=4.16.0-2+deb11u1 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR updates Debian libc and libc-bin packages.

The old version is deprecated and found in 
https://github.com/scalar-labs/docker/actions/runs/3729398402/jobs/6325270032