### PR TITLE
Update deprecated feature `set-output` in workflow

### DIFF
--- a/.github/workflows/jre8-release.yml
+++ b/.github/workflows/jre8-release.yml
@@ -14,7 +14,7 @@ jobs:
         id: version
         run: |
           VERSION=$(echo ${{ github.ref }} | sed -e "s#refs/tags/jre8-##g")
-          echo ::set-output name=version::${VERSION}
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Check out codes
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR updates the deprecated feature `set-output` in the GitHub Actions.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Please take a look!