### PR TITLE
Fix CVE-2023-0464 and CVE-2023-2650

### DIFF
--- a/jdk/8/Dockerfile
+++ b/jdk/8/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgcrypt20=1.8.7-6 \
     libgnutls30=3.7.1-5+deb11u3 \
     libhogweed6=3.7.3-1 \
-    libssl1.1=1.1.1n-0+deb11u4 \
-    openssl=1.1.1n-0+deb11u4 \
+    libssl1.1=1.1.1n-0+deb11u5 \
+    openssl=1.1.1n-0+deb11u5 \
     libgmp10=2:6.2.1+dfsg-1+deb11u1 \
     zlib1g=1:1.2.11.dfsg-2+deb11u2 \
     gzip=1.10-4+deb11u1 \

--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -5,8 +5,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgcrypt20=1.8.7-6 \
     libgnutls30=3.7.1-5+deb11u3 \
     libhogweed6=3.7.3-1 \
-    libssl1.1=1.1.1n-0+deb11u4 \
-    openssl=1.1.1n-0+deb11u4 \
+    libssl1.1=1.1.1n-0+deb11u5 \
+    openssl=1.1.1n-0+deb11u5 \
     libgmp10=2:6.2.1+dfsg-1+deb11u1 \
     zlib1g=1:1.2.11.dfsg-2+deb11u2 \
     gzip=1.10-4+deb11u1 \


### PR DESCRIPTION
This PR upgrades the libssl1.1 and openssl packages to fix CVE-2023-0464 and CVE-2023-2650