### PR TITLE
Update PostgreSQL version of jdk-postgres Dockerfile

### DIFF
--- a/.github/workflows/jdk8-postgres15-scan.yml
+++ b/.github/workflows/jdk8-postgres15-scan.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Build the Docker image locally for scanning
       run: |
-        LAST_JDK8_VERSION=$(git tag | grep jdk8 | sed 's/jdk8-//g' | sort -r | head -n 1)
+        LAST_JDK8_VERSION=$(git tag | grep jdk8 | sed 's/jdk8-//g' | sort -r --version-sort | head -n 1)
         echo "Scan with the base image version: $LAST_JDK8_VERSION"
         docker build ./jdk-postgres/8-15 --build-arg BASE_IMAGE_VERSION="$LAST_JDK8_VERSION" -t can_be_removed
 

--- a/.github/workflows/jdk8-postgres15-scan.yml
+++ b/.github/workflows/jdk8-postgres15-scan.yml
@@ -13,9 +13,21 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.CR_PAT }}
 
     - name: Build the Docker image locally for scanning
-      run: docker build ./jdk-postgres/8-15 -t can_be_removed
+      run: |
+        LAST_JDK8_VERSION=$(git tag | grep jdk8 | sed 's/jdk8-//g' | sort -r | head -n 1)
+        echo "Scan with the base image version: $LAST_JDK8_VERSION"
+        docker build ./jdk-postgres/8-15 --build-arg BASE_IMAGE_VERSION="$LAST_JDK8_VERSION" -t can_be_removed
 
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master

--- a/.github/workflows/jdk8-release.yml
+++ b/.github/workflows/jdk8-release.yml
@@ -72,3 +72,5 @@ jobs:
           push: true
           tags: ghcr.io/scalar-labs/jdk8-postgres15:${{ needs.release-jdk8.outputs.version }}
           platforms: linux/amd64,linux/arm64/v8
+          build-args:
+            - BASE_IMAGE_VERSION=${{ needs.release-jdk8.outputs.version }}

--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -1,19 +1,9 @@
 #
 # NOTE: This dockerfile is based on the official postgres dockerfile
-# See https://github.com/docker-library/postgres
+# https://github.com/docker-library/postgres/blob/1f5d48fa85938d91a757f95b01069fe3f68c46bc/15/bullseye/Dockerfile
 #
 
 FROM ghcr.io/scalar-labs/jdk8:1.0.0
-
-RUN set -ex; \
-	if ! command -v gpg > /dev/null; then \
-		apt-get update; \
-		apt-get install -y --no-install-recommends \
-			gnupg \
-			dirmngr \
-		; \
-		rm -rf /var/lib/apt/lists/*; \
-	fi
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -24,6 +14,13 @@ RUN set -eux; \
 # see https://github.com/docker-library/postgres/issues/274
 	mkdir -p /var/lib/postgresql; \
 	chown -R postgres:postgres /var/lib/postgresql
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		gnupg \
+	; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 # https://github.com/tianon/gosu/releases
@@ -80,13 +77,13 @@ RUN set -ex; \
 	mkdir -p /usr/local/share/keyrings/; \
 	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
 	gpg --batch --export --armor "$key" > /usr/local/share/keyrings/postgres.gpg.asc; \
-	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	gpgconf --kill all; \
 	rm -rf "$GNUPGHOME"
 
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 15.2-1.pgdg110+1
+ENV PG_VERSION 15.3-1.pgdg110+1
 
 RUN set -ex; \
 	\
@@ -96,7 +93,7 @@ RUN set -ex; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	aptRepo="[ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] http://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main $PG_MAJOR"; \
 	case "$dpkgArch" in \
-		amd64 | arm64 | ppc64el) \
+		amd64 | arm64 | ppc64el | s390x) \
 # arches officialy built by upstream
 			echo "deb $aptRepo" > /etc/apt/sources.list.d/pgdg.list; \
 			apt-get update; \

--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -3,7 +3,9 @@
 # https://github.com/docker-library/postgres/blob/1f5d48fa85938d91a757f95b01069fe3f68c46bc/15/bullseye/Dockerfile
 #
 
-FROM ghcr.io/scalar-labs/jdk8:1.0.2
+ARG BASE_IMAGE_VERSION
+
+FROM ghcr.io/scalar-labs/jdk8:${BASE_IMAGE_VERSION}
 
 # explicitly set user/group IDs
 RUN set -eux; \

--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -3,7 +3,7 @@
 # https://github.com/docker-library/postgres/blob/1f5d48fa85938d91a757f95b01069fe3f68c46bc/15/bullseye/Dockerfile
 #
 
-FROM ghcr.io/scalar-labs/jdk8:1.0.0
+FROM ghcr.io/scalar-labs/jdk8:1.0.2
 
 # explicitly set user/group IDs
 RUN set -eux; \


### PR DESCRIPTION
## Context

The build of `jdk8-postgres15` failed due to the missing `postgresql-15` package. 
https://github.com/scalar-labs/docker/actions/runs/5208536349/jobs/9397309534

## What are changed

- Since the `Dockerfile` of `jdk8-postgres15` comes from https://github.com/docker-library/postgres, the file is updated to the latest version
   - The above error occurred because the minor version specified in this file is outdated.
- The base image version is also updated

## Other considerations

None