### PR TITLE
Fix jdk8-postgres15 build error

### DIFF
--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -85,7 +85,7 @@ RUN set -ex; \
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 15.3-1.pgdg110+1
+ENV PG_VERSION 15.4-2.pgdg110+1
 
 RUN set -ex; \
 	\


### PR DESCRIPTION
## Description

After #27 was merged, the CI task to build jdk8-postgres15 failed. This occurred because the PostgreSQL with the version specified in the Dockerfile is no longer available in the repository.

## Related issues and/or PRs

None

## Changes made

Upgraded the PostgreSQL version

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [ ] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.

## Additional notes (optional)

None