### PR TITLE
Fix CVE-2023-47038

### DIFF
--- a/jdk/8/Dockerfile
+++ b/jdk/8/Dockerfile
@@ -26,4 +26,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtinfo6=6.2+20201114-2+deb11u2 \
     ncurses-base=6.2+20201114-2+deb11u2 \
     ncurses-bin=6.2+20201114-2+deb11u2 \
+    perl-base=5.32.1-4+deb11u3 \
     && rm -rf /var/lib/apt/lists/*

--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -26,4 +26,5 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libtinfo6=6.2+20201114-2+deb11u2 \
     ncurses-base=6.2+20201114-2+deb11u2 \
     ncurses-bin=6.2+20201114-2+deb11u2 \
+    perl-base=5.32.1-4+deb11u3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Description

This PR fixed CVE-2023-47038.

It was detected by Trivy.

```
┌───────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────┬──────────────────────────────────────────────────────────────┐
│  Library  │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version   │                            Title                             │
├───────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────┼──────────────────────────────────────────────────────────────┤
│ perl-base │ CVE-2023-47038 │ HIGH     │ fixed  │ 5.32.1-4+deb11u2  │ 5.32.1-4+deb11u3 │ perl: Write past buffer end via illegal user-defined Unicode │
│           │                │          │        │                   │                  │ property                                                     │
│           │                │          │        │                   │                  │ https://avd.aquasec.com/nvd/cve-2023-47038                   │
└───────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────┴──────────────────────────────────────────────────────────────┘
```

## Related issues and/or PRs

N/A

## Changes made

- revised Dockerfile(s) to update the related OS level package.

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
