### PR TITLE
Upgrade PostgreSQL version of jdk8-postgres15

### DIFF
--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -85,7 +85,7 @@ RUN set -ex; \
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 15.4-2.pgdg110+1
+ENV PG_VERSION 15.6-1.pgdg110+2
 
 RUN set -ex; \
 	\


### PR DESCRIPTION
## Description

This PR upgrades the version of PostgresQL 15.

This is detected by https://github.com/scalar-labs/docker/actions/runs/7983160609 when we tried to release the in-house image https://github.com/orgs/scalar-labs/packages/container/package/jdk8-postgres15

I used https://apt.postgresql.org/pub/repos/apt/dists/bullseye-pgdg/main/binary-amd64/ to check the latest package.

## Related issues and/or PRs

N/A

## Changes made

- revised the Dockerfile to upgrade the version

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
