### PR TITLE
Upgrade libc Debian package to version 2.31-13+deb11u7

### DIFF
--- a/jdk/8/Dockerfile
+++ b/jdk/8/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg=1.20.10 \
     libtirpc-common=1.3.1-1+deb11u1 \
     libtirpc3=1.3.1-1+deb11u1 \
-    libc-bin=2.31-13+deb11u7 \
-    libc6=2.31-13+deb11u7 \
+    libc-bin=2.31-13+deb11u9 \
+    libc6=2.31-13+deb11u9 \
     libpcre2-8-0=10.36-2+deb11u1 \
     libtasn1-6=4.16.0-2+deb11u1 \
     libdb5.3=5.3.28+dfsg1-0.8 \

--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -14,8 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     dpkg=1.20.10 \
     libtirpc-common=1.3.1-1+deb11u1 \
     libtirpc3=1.3.1-1+deb11u1 \
-    libc-bin=2.31-13+deb11u7 \
-    libc6=2.31-13+deb11u7 \
+    libc-bin=2.31-13+deb11u9 \
+    libc6=2.31-13+deb11u9 \
     libpcre2-8-0=10.36-2+deb11u1 \
     libtasn1-6=4.16.0-2+deb11u1 \
     libdb5.3=5.3.28+dfsg1-0.8 \


### PR DESCRIPTION
## Description

This PR upgrades the Debian libc package to version `2.31-13+deb11u7`. The old packages are unable to download. This issue is found in https://github.com/scalar-labs/docker/actions/runs/8808807438

## Related issues and/or PRs

https://github.com/scalar-labs/docker/actions/runs/8808807438

## Changes made

- revised the Dockerfiles

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.