### PR TITLE
Handle CVE-2024-0553 and CVE-2024-0567

### DIFF
--- a/jdk-postgres/8-15/Dockerfile
+++ b/jdk-postgres/8-15/Dockerfile
@@ -85,7 +85,7 @@ RUN set -ex; \
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 15.6-1.pgdg110+2
+ENV PG_VERSION 15.7-1.pgdg110+1
 
 RUN set -ex; \
 	\

--- a/jdk/8/Dockerfile
+++ b/jdk/8/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8u322-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     liblz4-1=1.9.3-2 \
     libgcrypt20=1.8.7-6 \
-    libgnutls30=3.7.1-5+deb11u3 \
+    libgnutls30=3.7.1-5+deb11u5 \
     libhogweed6=3.7.3-1 \
     libssl1.1=1.1.1n-0+deb11u5 \
     openssl=1.1.1n-0+deb11u5 \

--- a/jre/8/Dockerfile
+++ b/jre/8/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8u322-jre-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     liblz4-1=1.9.3-2 \
     libgcrypt20=1.8.7-6 \
-    libgnutls30=3.7.1-5+deb11u3 \
+    libgnutls30=3.7.1-5+deb11u5 \
     libhogweed6=3.7.3-1 \
     libssl1.1=1.1.1n-0+deb11u5 \
     openssl=1.1.1n-0+deb11u5 \


### PR DESCRIPTION
## Description

This PR upgrades the Debian package `libgnutls30` to patch CVE-2024-0553 and CVE-2024-0567.

```
┌─────────────┬───────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────┐
│   Library   │ Vulnerability │ Severity │ Status │ Installed Version │  Fixed Version  │                          Title                           │
├─────────────┼───────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────┤
│ libgnutls30 │ CVE-2024-0553 │ HIGH     │ fixed  │ 3.7.1-5+deb11u3   │ 3.7.1-5+deb11u5 │ gnutls: incomplete fix for CVE-2023-5981                 │
│             │               │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-0553                │
│             ├───────────────┤          │        │                   │                 ├──────────────────────────────────────────────────────────┤
│             │ CVE-2024-0567 │          │        │                   │                 │ gnutls: rejects certificate chain with distributed trust │
│             │               │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-0567                │
└─────────────┴───────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────┘
```

We got the report from CI at https://github.com/scalar-labs/docker/actions/runs/9769591056/job/26969320568

It also upgrades the PostgreSQL 15 package source since the old one no longer exists.


## Related issues and/or PRs

N/A

## Changes made

- revised Dockerfiles

## Checklist

- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes.
- [ ] Any remaining open issues linked to this PR are documented and up-to-date (Jira, GitHub, etc.).
- [x] Tests (unit, integration, etc.) have been added for the changes.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes in other PRs have been merged and published.
